### PR TITLE
Handle invalid JSON in inference WebSocket

### DIFF
--- a/src/rose_inference/main.py
+++ b/src/rose_inference/main.py
@@ -59,7 +59,11 @@ async def inference_endpoint(websocket: WebSocket) -> None:
     try:
         # Process inference requests on this connection sequentially
         async for message in websocket.iter_text():
-            request_data = json.loads(message)
+            try:
+                request_data = json.loads(message)
+            except json.JSONDecodeError:
+                await websocket.send_json({"type": "error", "error": "Invalid JSON"})
+                continue
 
             try:
                 config = request_data["config"]


### PR DESCRIPTION
## Summary
- Guard against invalid JSON messages in the inference WebSocket and send an error event

## Testing
- `pre-commit run --files src/rose_inference/main.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68913639657c833088b7e878dd6a057b