### PR TITLE
Add license metadata to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,12 @@ description = "ROSE - Run your own LLM server"
 readme = "README.md"
 requires-python = ">=3.13,<4.0"
 authors = [{ name = "Garden Variety AI" }]
+license = { file = "LICENSE" }
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.13",
+]
 dependencies = [
   "fastapi>=0.110.0",
   "uvicorn>=0.27.1",


### PR DESCRIPTION
## Summary
- specify LICENSE file in project metadata
- declare MIT license and supported Python versions in classifiers

## Testing
- `pre-commit run --files pyproject.toml` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_689135f15f3c8330bba833f21f2ed424