### PR TITLE
Use package version in FastAPI app

### DIFF
--- a/src/rose_server/app.py
+++ b/src/rose_server/app.py
@@ -11,6 +11,7 @@ os.environ["POSTHOG_DISABLED"] = "1"
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from rose_server import __version__
 from rose_server.config.settings import settings
 from rose_server.database import create_all_tables
 from rose_server.middleware.auth import AuthMiddleware
@@ -63,7 +64,7 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title="ROSE",
         description="A service for generating responses using different LLM modes",
-        version="0.1.0",
+        version=__version__,
         lifespan=lifespan,
     )
     app.add_middleware(


### PR DESCRIPTION
## Summary
- import rose_server.__version__ and provide it to the FastAPI application

## Testing
- `pre-commit run --files src/rose_server/app.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6891357ed9688330b49ca872d27285c2